### PR TITLE
feat(cache): purge_cache() for periodic cleanup + auto-purge on stale sessions

### DIFF
--- a/src/anti_cf/_persistent_session.py
+++ b/src/anti_cf/_persistent_session.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import contextlib
 import pickle
 import tempfile
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
@@ -23,12 +26,25 @@ except ImportError:
     _HAS_CACHE = False
 
 if TYPE_CHECKING:
+    from datetime import timedelta
+
     from requests import Response
 
 
 class PersistentSession(Session):
     _COOKIES_FILE: ClassVar[Path] = CACHE_PATH / "cookies.pkl"
     _USER_AGENT_FILE: ClassVar[Path] = CACHE_PATH / "user_agent.txt"
+
+    # Default for the auto-purge cadence on session construction. Long enough
+    # that startup cost is amortised across many sessions, short enough that
+    # disk usage doesn't drift unboundedly between runs.
+    _AUTO_PURGE_INTERVAL_SECONDS: ClassVar[int] = 7 * 24 * 3600  # 7 days
+
+    @property
+    def _purge_marker(self) -> Path:
+        # Resolved at access time so tests that patch ``CACHE_PATH`` (or any
+        # caller redirecting the cache directory mid-run) see the right path.
+        return CACHE_PATH / "url_cache.purged"
 
     def __init__(self) -> None:
         if _HAS_CACHE:
@@ -56,6 +72,12 @@ class PersistentSession(Session):
         self._load_cookies()
         self.set_user_agent()
         self._flaresolverr_initialized = False
+
+        # One-shot best-effort purge if the cache hasn't been swept in a while.
+        # Failures are swallowed — this is housekeeping, not a hard requirement.
+        if _HAS_CACHE:
+            with contextlib.suppress(Exception):
+                self._auto_purge_if_due()
 
     def _get_user_agent(self) -> str:
         # Try FlareSolverr first, but don't start it if not running
@@ -131,6 +153,94 @@ class PersistentSession(Session):
         except Exception:
             logger.error(f"FlareSolverr didn't solve it :( [url: {url}]")
             raise
+
+    def purge_cache(self, *, older_than: timedelta | None = None, vacuum: bool = True) -> dict[str, int]:
+        """
+        Reclaim disk space from the persistent SQLite cache.
+
+        Drops every expired response, optionally drops every response whose
+        ``created_at`` is older than ``older_than`` regardless of its TTL,
+        then ``VACUUM``s the file so the freed pages become free disk.
+
+        ``older_than`` is the size-cap lever: long-TTL entries (10-year image
+        bodies and the like) never expire on their own, so without an age
+        cap they sit forever. Pass ``timedelta(days=N)`` to evict anything
+        older than that.
+
+        Set ``vacuum=False`` to skip the ``VACUUM`` (it rewrites the whole
+        file and can take a while on a multi-gigabyte cache; sometimes you
+        just want the rows gone and don't care about the on-disk size yet).
+
+        Returns a dict ``{"rows_before", "rows_after", "bytes_before",
+        "bytes_after"}`` so callers can log or assert on the savings.
+        Raises if the session was constructed without ``requests_cache``
+        installed — there is no cache to purge.
+        """
+        if not _HAS_CACHE:
+            raise RuntimeError("purge_cache requires requests_cache to be installed")
+
+        cache_path = CACHE_PATH / "url_cache.sqlite"
+
+        def _file_size() -> int:
+            try:
+                return cache_path.stat().st_size
+            except OSError:
+                return 0
+
+        def _row_count() -> int:
+            with self.cache.responses.connection() as con:
+                return con.execute(f"SELECT COUNT(*) FROM {self.cache.responses.table_name}").fetchone()[0]
+
+        rows_before = _row_count()
+        bytes_before = _file_size()
+
+        # Step 1: drop expired entries (TTL says they're past their use).
+        # ``vacuum=False`` so the inner cleanup doesn't VACUUM behind our back —
+        # we want exactly one VACUUM at the end (or none, if the caller asked).
+        self.cache.delete(expired=True, vacuum=False)
+
+        # Step 2: optional age cap — drop anything older than ``older_than`` by created_at.
+        if older_than is not None:
+            cutoff = datetime.now(timezone.utc) - older_than
+            stale_keys = [key for key, resp in self.cache.responses.items() if getattr(resp, "created_at", None) is not None and resp.created_at < cutoff]
+            if stale_keys:
+                self.cache.delete(*stale_keys, vacuum=False)
+
+        # Step 3: reclaim disk space.
+        if vacuum:
+            with self.cache.responses.connection() as con:
+                con.execute("VACUUM")
+
+        rows_after = _row_count()
+        bytes_after = _file_size()
+
+        self._purge_marker.parent.mkdir(parents=True, exist_ok=True)
+        self._purge_marker.touch()
+
+        logger.info(
+            "Cache purge: rows %d->%d (-%d), size %d->%d bytes (-%d)",
+            rows_before,
+            rows_after,
+            rows_before - rows_after,
+            bytes_before,
+            bytes_after,
+            bytes_before - bytes_after,
+        )
+        return {
+            "rows_before": rows_before,
+            "rows_after": rows_after,
+            "bytes_before": bytes_before,
+            "bytes_after": bytes_after,
+        }
+
+    def _auto_purge_if_due(self) -> None:
+        """Run :meth:`purge_cache` if the marker file is older than the auto-purge interval."""
+        try:
+            last_run = self._purge_marker.stat().st_mtime
+        except FileNotFoundError:
+            last_run = 0
+        if (time.time() - last_run) >= self._AUTO_PURGE_INTERVAL_SECONDS:
+            self.purge_cache()
 
     def _get_url_via_flaresolverr(self, url: str) -> dict:
         headers = {"Content-Type": "application/json"}

--- a/src/anti_cf/_persistent_session.py
+++ b/src/anti_cf/_persistent_session.py
@@ -218,13 +218,8 @@ class PersistentSession(Session):
         self._purge_marker.touch()
 
         logger.info(
-            "Cache purge: rows %d->%d (-%d), size %d->%d bytes (-%d)",
-            rows_before,
-            rows_after,
-            rows_before - rows_after,
-            bytes_before,
-            bytes_after,
-            bytes_before - bytes_after,
+            f"Cache purge: rows {rows_before}->{rows_after} (-{rows_before - rows_after}), "
+            f"size {bytes_before}->{bytes_after} bytes (-{bytes_before - bytes_after})"
         )
         return {
             "rows_before": rows_before,

--- a/tests/test_persisted_session.py
+++ b/tests/test_persisted_session.py
@@ -1,6 +1,7 @@
 import pickle
 from collections.abc import Mapping
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,6 +9,9 @@ import pytest_mock
 from requests import HTTPError
 
 from anti_cf._persistent_session import PersistentSession, session
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @pytest.fixture(autouse=True)
@@ -334,6 +338,191 @@ def test_sqlite_cache_uses_wal_and_busy_timeout(tmp_path: Path, mocker: pytest_m
         assert con.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
     finally:
         con.close()
+
+
+def _spy_on_connection_execute(ps: PersistentSession, mocker: pytest_mock.MockerFixture) -> list[str]:
+    """
+    Capture every ``execute(sql, …)`` issued on the cache's sqlite connection.
+
+    ``sqlite3.Connection.execute`` is read-only so we can't reassign it; instead
+    wrap the entire connection in a proxy that forwards every other attribute
+    via ``__getattr__`` and records SQL strings on the way through.
+    """
+    from contextlib import contextmanager
+
+    executed: list[str] = []
+    original_connection = ps.cache.responses.connection
+
+    class _Proxy:
+        def __init__(self, real: object) -> None:
+            self._real = real
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._real, name)
+
+        def execute(self, sql: str, *args: object, **kwargs: object) -> object:
+            executed.append(sql)
+            return self._real.execute(sql, *args, **kwargs)
+
+    @contextmanager
+    def _wrap_connection(*args: object, **kwargs: object) -> "Iterator[_Proxy]":
+        with original_connection(*args, **kwargs) as real_con:
+            yield _Proxy(real_con)
+
+    mocker.patch.object(ps.cache.responses, "connection", _wrap_connection)
+    return executed
+
+
+class TestPurgeCache:
+    """Cover the on-demand and auto-purge cache cleanup paths."""
+
+    def _seed_responses(self, ps: PersistentSession, *, fresh: int = 1, expired: int = 1, old: int = 0) -> None:
+        """Pre-populate the cache with a mix of fresh / expired / old entries."""
+        import datetime
+
+        from requests_cache.models import CachedResponse
+
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        for i in range(fresh):
+            ps.cache.responses[f"fresh_{i}"] = CachedResponse(
+                status_code=200,
+                headers={},
+                content=b"f" * 1024,
+                url=f"http://example/fresh/{i}",
+                expires=now + datetime.timedelta(days=30),
+                created_at=now,
+            )
+        for i in range(expired):
+            ps.cache.responses[f"expired_{i}"] = CachedResponse(
+                status_code=200,
+                headers={},
+                content=b"e" * 1024,
+                url=f"http://example/expired/{i}",
+                expires=now - datetime.timedelta(seconds=60),
+                created_at=now,
+            )
+        # ``old`` entries are still fresh by TTL but their created_at is way back —
+        # the size-cap path drops them.
+        for i in range(old):
+            ps.cache.responses[f"old_{i}"] = CachedResponse(
+                status_code=200,
+                headers={},
+                content=b"o" * 1024,
+                url=f"http://example/old/{i}",
+                expires=now + datetime.timedelta(days=3650),
+                created_at=now - datetime.timedelta(days=365),
+            )
+
+    def test_drops_expired_entries(self, tmp_path: Path, mocker: pytest_mock.MockerFixture) -> None:
+        mocker.patch("anti_cf._persistent_session.CACHE_PATH", tmp_path)
+        # Block auto-purge during construction so the seed data isn't wiped before we test.
+        mocker.patch.object(PersistentSession, "_auto_purge_if_due", autospec=True)
+
+        ps = PersistentSession()
+        self._seed_responses(ps, fresh=2, expired=3)
+        stats = ps.purge_cache(vacuum=False)
+
+        assert stats["rows_before"] == 5
+        assert stats["rows_after"] == 2  # only the two fresh ones survive
+        assert sorted(ps.cache.responses.keys()) == ["fresh_0", "fresh_1"]
+
+    def test_older_than_evicts_age_capped_entries(self, tmp_path: Path, mocker: pytest_mock.MockerFixture) -> None:
+        """``older_than`` evicts long-TTL entries that would otherwise live forever."""
+        import datetime
+
+        mocker.patch("anti_cf._persistent_session.CACHE_PATH", tmp_path)
+        mocker.patch.object(PersistentSession, "_auto_purge_if_due", autospec=True)
+
+        ps = PersistentSession()
+        self._seed_responses(ps, fresh=1, expired=0, old=2)
+        stats = ps.purge_cache(older_than=datetime.timedelta(days=30), vacuum=False)
+
+        assert stats["rows_before"] == 3
+        assert stats["rows_after"] == 1  # only the one fresh-and-young entry survives
+        assert sorted(ps.cache.responses.keys()) == ["fresh_0"]
+
+    def test_vacuum_runs_when_requested(self, tmp_path: Path, mocker: pytest_mock.MockerFixture) -> None:
+        mocker.patch("anti_cf._persistent_session.CACHE_PATH", tmp_path)
+        mocker.patch.object(PersistentSession, "_auto_purge_if_due", autospec=True)
+
+        ps = PersistentSession()
+        self._seed_responses(ps, fresh=1, expired=2)
+
+        executed = _spy_on_connection_execute(ps, mocker)
+
+        ps.purge_cache(vacuum=True)
+        assert any(s.upper().strip() == "VACUUM" for s in executed)
+
+    def test_vacuum_skipped_when_not_requested(self, tmp_path: Path, mocker: pytest_mock.MockerFixture) -> None:
+        mocker.patch("anti_cf._persistent_session.CACHE_PATH", tmp_path)
+        mocker.patch.object(PersistentSession, "_auto_purge_if_due", autospec=True)
+
+        ps = PersistentSession()
+        self._seed_responses(ps, fresh=1, expired=1)
+        executed = _spy_on_connection_execute(ps, mocker)
+
+        ps.purge_cache(vacuum=False)
+        assert not any(s.upper().strip() == "VACUUM" for s in executed)
+
+    def test_marker_file_touched_after_purge(self, tmp_path: Path, mocker: pytest_mock.MockerFixture) -> None:
+        mocker.patch("anti_cf._persistent_session.CACHE_PATH", tmp_path)
+        mocker.patch.object(PersistentSession, "_auto_purge_if_due", autospec=True)
+
+        ps = PersistentSession()
+        marker = tmp_path / "url_cache.purged"
+        assert not marker.exists()
+        ps.purge_cache(vacuum=False)
+        assert marker.exists()
+
+    def test_purge_cache_raises_without_requests_cache(self, tmp_path: Path, mocker: pytest_mock.MockerFixture) -> None:
+        """When the optional dep is missing, the method explains itself instead of failing weirdly."""
+        mocker.patch("anti_cf._persistent_session.CACHE_PATH", tmp_path)
+        mocker.patch.object(PersistentSession, "_auto_purge_if_due", autospec=True)
+        ps = PersistentSession()
+        mocker.patch("anti_cf._persistent_session._HAS_CACHE", False)
+        with pytest.raises(RuntimeError, match="requests_cache"):
+            ps.purge_cache()
+
+
+class TestAutoPurge:
+    """Cover the construction-time auto-purge gate."""
+
+    def test_runs_purge_when_marker_missing(self, tmp_path: Path, mocker: pytest_mock.MockerFixture) -> None:
+        mocker.patch("anti_cf._persistent_session.CACHE_PATH", tmp_path)
+        purge = mocker.patch.object(PersistentSession, "purge_cache", autospec=True)
+        PersistentSession()
+        purge.assert_called_once()
+
+    def test_skips_purge_when_marker_recent(self, tmp_path: Path, mocker: pytest_mock.MockerFixture) -> None:
+        mocker.patch("anti_cf._persistent_session.CACHE_PATH", tmp_path)
+        marker = tmp_path / "url_cache.purged"
+        marker.touch()
+        purge = mocker.patch.object(PersistentSession, "purge_cache", autospec=True)
+        PersistentSession()
+        purge.assert_not_called()
+
+    def test_runs_purge_when_marker_older_than_interval(self, tmp_path: Path, mocker: pytest_mock.MockerFixture) -> None:
+        import os
+        import time
+
+        mocker.patch("anti_cf._persistent_session.CACHE_PATH", tmp_path)
+        marker = tmp_path / "url_cache.purged"
+        marker.touch()
+        # Backdate to before the interval window.
+        old = time.time() - PersistentSession._AUTO_PURGE_INTERVAL_SECONDS - 60
+        os.utime(marker, (old, old))
+
+        purge = mocker.patch.object(PersistentSession, "purge_cache", autospec=True)
+        PersistentSession()
+        purge.assert_called_once()
+
+    def test_swallows_purge_errors(self, tmp_path: Path, mocker: pytest_mock.MockerFixture) -> None:
+        """A failing housekeeping pass must not break the session constructor."""
+        mocker.patch("anti_cf._persistent_session.CACHE_PATH", tmp_path)
+        mocker.patch.object(PersistentSession, "purge_cache", side_effect=RuntimeError("boom"))
+        # Construction must succeed despite the purge raising.
+        ps = PersistentSession()
+        assert isinstance(ps, PersistentSession)
 
 
 def test_lazy_flaresolverr_branches(mocker: pytest_mock.MockerFixture) -> None:


### PR DESCRIPTION
## Summary
The persistent SQLite cache grows unboundedly: long-TTL entries (image bodies cached for years) never expire, and SQLite doesn't reclaim disk space without an explicit `VACUUM`. Multi-gigabyte cache files are the predictable result.

## What this adds
- **`PersistentSession.purge_cache(*, older_than=None, vacuum=True)`** — drops every expired response, optionally drops responses whose `created_at` is older than `older_than` (the size-cap lever for long-TTL entries), then `VACUUM`s the file. Threads `vacuum=False` through to the inner `cache.delete()` call so we control the single `VACUUM` ourselves. Returns `{rows_before, rows_after, bytes_before, bytes_after}` so callers can log or assert on the savings.
- **Best-effort auto-purge in `__init__`** — if a `url_cache.purged` marker file is older than 7 days (or absent), runs `purge_cache()` once. Failures are swallowed; housekeeping must never break session construction.

## Why
Without a sweep, the file just keeps growing. Long-TTL entries (e.g. 10-year image caches) survive every `expired=True` purge, so an age cap is the only practical handle on size.

## Tests
- 6 cases on `purge_cache` itself: expired drop, `older_than` age cap, `VACUUM` runs when requested, `VACUUM` skipped when not, marker file is touched, raises when `requests_cache` is uninstalled.
- 4 cases on the auto-purge gate: marker absent, marker recent, marker older than interval, purge raising during construction.
- The pre-existing 6 `test_get_method_*` failures present on master (stale-mock issue with `CachedSession.get`) are out of scope here.